### PR TITLE
add options to fully ignore external storage

### DIFF
--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -46,7 +46,7 @@ var files_settings = {
 
 	updateSettingPage: function (result) {
 		files_elements.files_local.prop('checked', (result.files_local === '1'));
-		files_elements.files_external.prop('checked', (result.files_external === '1'));
+		files_elements.files_external.val(result.files_external);
 		files_elements.files_group_folders.prop('checked', (result.files_group_folders === '1'));
 		files_elements.files_encrypted.prop('checked', (result.files_encrypted === '1'));
 		files_elements.files_federated.prop('checked', (result.files_federated === '1'));
@@ -63,7 +63,7 @@ var files_settings = {
 	saveSettings: function () {
 		var data = {
 			files_local: (files_elements.files_local.is(':checked')) ? 1 : 0,
-			files_external: (files_elements.files_external.is(':checked')) ? 1 : 0,
+			files_external: files_elements.files_external.val(),
 			files_encrypted: (files_elements.files_encrypted.is(':checked')) ? 1 : 0,
 			files_federated: (files_elements.files_federated.is(':checked')) ? 1 : 0,
 			files_group_folders: (files_elements.files_group_folders.is(':checked')) ? 1 : 0,

--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -253,6 +253,12 @@ class FilesService {
 			return $documents;
 		}
 
+		if ($this->configService->getAppValue(ConfigService::FILES_EXTERNAL) === '2'
+			&& $node->getMountPoint()
+					->getMountType() === 'external') {
+			return $documents;
+		}
+
 		$files = $node->getDirectoryListing();
 		foreach ($files as $file) {
 
@@ -454,6 +460,12 @@ class FilesService {
 
 		try {
 			$file = $this->getFileFromIndex($index);
+
+			if ($file->getMountPoint()
+					 ->getMountType() === 'external'
+				&& $this->configService->getAppValue(ConfigService::FILES_EXTERNAL) === '2') {
+				throw new Exception();
+			}
 		} catch (Exception $e) {
 			$index->setStatus(IIndex::INDEX_REMOVE);
 			$document = new FilesDocument($index->getProviderId(), $index->getDocumentId());

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -2,7 +2,6 @@
 declare(strict_types=1);
 
 
-
 /**
  * Files_FullTextSearch - Index the content of your files
  *
@@ -63,7 +62,11 @@ Util::addScript(Application::APP_NAME, 'admin');
 				<em><?php p($l->t('Index the content of external files.')); ?></em>
 			</div>
 			<div class="div-table-col">
-				<input type="checkbox" id="files_external" value="1"/>
+				<select id="files_external">
+					<option value="0"><?php p($l->t('Index path only')); ?></option>
+					<option value="1"><?php p($l->t('Index path and content')); ?></option>
+					<option value="2"><?php p($l->t('Do not index path nor content')); ?></option>
+				</select>
 			</div>
 		</div>
 


### PR DESCRIPTION
Add a new option in the settings to fully ignore (path+content) on external storage #456