### PR TITLE
Update ExternalFilesService.php

### DIFF
--- a/lib/Service/ExternalFilesService.php
+++ b/lib/Service/ExternalFilesService.php
@@ -239,6 +239,10 @@ class ExternalFilesService {
 	private function getMountPoint(Node $file): MountPoint {
 
 		try {
+			if($file->getMountPoint()->getMountId() === null){
+                             throw new FileIsNotIndexableException('getMountId is null');
+                        }
+			
 			return $this->getExternalMountById(
 				$file->getMountPoint()
 					 ->getMountId()


### PR DESCRIPTION
$file->getMountPoint()->getMountId() exception handling. Avoid null object and throw an exception.
A quick and dirty fix!

Fix issue nextcloud#79