### PR TITLE
Fix for #72 - occ fulltextsearch:search throws unhandled exception

### DIFF
--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -112,7 +112,9 @@ class SearchService {
 		$this->searchQueryInOptions($request);
 		$this->searchQueryFiltersExtension($request);
 		$this->searchQueryFiltersSource($request);
-
+		if($this->userId === null) {
+			$this->userId = $this->miscService->secureUsername($request->getAuthor());
+		}
 		$request->addPart('comments');
 		$this->extensionService->searchRequest($request);
 	}


### PR DESCRIPTION
Fix for  unhandled exception, when SearchService is being used by
occ fulltextsearch:search command.
We ensure, that userId member of SearchService is set properly.

This commit fixes issue #72