### PR TITLE
Fix file not found exception

### DIFF
--- a/lib/Listeners/FileRenamed.php
+++ b/lib/Listeners/FileRenamed.php
@@ -55,7 +55,7 @@ class FileRenamed extends ListenersCore implements IEventListener {
 			return;
 		}
 
-		$node = $event->getSource();
+		$node = $event->getTarget();
 		try {
 			$this->fullTextSearchManager->updateIndexStatus(
 				'files', (string)$node->getId(), IIndex::INDEX_META


### PR DESCRIPTION
Related to https://github.com/nextcloud/fulltextsearch/issues/602#issuecomment-758258537

When a file is renamed the `NodeRenamedEvent->getSource()` returns a `NonExistingFile` which does not have a node id anymore. Instead the `NodeRenamedEvent->getTarget()` should be used which returns the "new" node holding the id of the renamed file. Note that the id does not change through the rename process.