### PR TITLE
fix indexing a given path with occ fulltextsearch:index

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -202,7 +202,7 @@ class FilesService {
 		if ($files instanceof Folder) {
 			return $this->getChunksFromDirectory($userId, $files);
 		} else {
-			return [$files];
+			return [$this->getPathFromRoot($files->getPath(), $userId, true)];
 		}
 	}
 


### PR DESCRIPTION
`occ fulltextsearch:index` allows passing a path to select what to index by passing `-- '{"path":"/foo/bar.pdf"}'`. Unfortunately, it doesn't work when given a path, due to `getChunksFromUser` returning a File instead of a path: https://github.com/nextcloud/files_fulltextsearch/blob/034c87c35e781d1483a7e948db1fc09338fcbcab/lib/Service/FilesService.php#L202-L206

which when cast to a string returns the empty string, followed by subsequent `generateIndexableDocuments` working on the root directory.

This PR changes the behavior of `getChunksFromUser` to return the file path as string, generated the same way as if it was a directory (as in `getChunksFromDirectory`).