### PR TITLE
Don't log full stacktrace if generateDocument fails

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -574,8 +574,8 @@ class FilesService {
 			$document->getIndex()
 					 ->setStatus(IIndex::INDEX_IGNORE);
 			$this->miscService->log(
-				'Exception while generateDocument: ' . $e->getMessage() . ' - trace: '
-				. json_encode($e->getTrace())
+				'Exception while generateDocument: ' . $e->getMessage() . ' ('. get_class($e) .') at '
+				. $e->getFile() . ' line ' . $e->getLine()
 			);
 		}
 	}


### PR DESCRIPTION
**Current situation**
If we trigger an index build (for example `sudo -u www-data php occ fulltextsearch:index`) every `Exception` inside `generateDocument` is logged into `nextcloud.log` with the complete stacktrace. Because the stacktrace contains a lot of  data object and every object inside the stacktrace is serialized i noticed that one log entry can have about 400kb of size. If there are a few documents which cannot be indexed this bloats the logfile with unneccessary information and slows down the indexing process.

**This PR**
This pull request strips out the stacktrace and narrows the log data down to the relevant information.