### PR TITLE
ignore invalid value returned by stat()

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -493,14 +493,18 @@ class FilesService {
 		}
 
 		$document->setModifiedTime($file->getMTime());
-
 		$stat = $file->stat();
-		$document->setMore(
-			[
-				'creationTime' => $this->getInt('ctime', $stat),
-				'accessedTime' => $this->getInt('atime', $stat)
-			]
-		);
+
+		if (is_array($stat)) {
+			$document->setMore(
+				[
+					'creationTime' => $this->getInt('ctime', $stat),
+					'accessedTime' => $this->getInt('atime', $stat)
+				]
+			);
+		} else {
+			$this->log(2, 'stat() on File #' . $file->getId() . ' is not an array: ' . json_encode($stat));
+		}
 
 		return $document;
 	}


### PR DESCRIPTION
should fix https://github.com/nextcloud/fulltextsearch/issues/703

This will avoid trying to add some metadata to the document if those metadata are not available