### PR TITLE
Update SearchService.php

### DIFF
--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -342,7 +342,7 @@ class SearchService {
 		}
 
 		$document->setLink(
-			$this->urlGenerator->linkToRoute('files.view.index', ['dir' => $dir, 'scrollto' => $filename])
+			$this->urlGenerator->linkToRoute('files.view.index', ['dir' => $this->withoutEndSlash($dir), 'openfile' => $document->getId(), 'scrollto' => $filename])
 		);
 	}
 


### PR DESCRIPTION
Typically, when searched for some document with the help of the universal search the document is opened, but not the location.

This PR will allow open files directly from the results of the search.

See https://github.com/nextcloud/files_fulltextsearch/issues/249