### PR TITLE
Add Option to Open Files Directly from Search Results

### DIFF
--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -41,6 +41,7 @@ var files_elements = {
 	files_pdf: null,
 	files_image: null,
 	files_audio: null,
+	files_open_result_directly: null,
 
 	init: function () {
 		files_elements.files_div = $('#files');
@@ -54,6 +55,7 @@ var files_elements = {
 		files_elements.files_pdf = $('#files_pdf');
 		files_elements.files_image = $('#files_image');
 		files_elements.files_audio = $('#files_audio');
+		files_elements.files_open_result_directly = $('#open_result_directly');
 
 		files_elements.files_local.on('change', files_elements.updateSettings);
 		files_elements.files_external.on('change', files_elements.updateSettings);
@@ -65,6 +67,7 @@ var files_elements = {
 		files_elements.files_pdf.on('change', files_elements.updateSettings);
 		files_elements.files_image.on('change', files_elements.updateSettings);
 		files_elements.files_audio.on('change', files_elements.updateSettings);
+		files_elements.files_open_result_directly.on('change', files_elements.updateSettings);
 	},
 
 

--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -55,7 +55,7 @@ var files_elements = {
 		files_elements.files_pdf = $('#files_pdf');
 		files_elements.files_image = $('#files_image');
 		files_elements.files_audio = $('#files_audio');
-		files_elements.files_open_result_directly = $('#open_result_directly');
+		files_elements.files_open_result_directly = $('#files_open_result_directly');
 
 		files_elements.files_local.on('change', files_elements.updateSettings);
 		files_elements.files_external.on('change', files_elements.updateSettings);

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -55,6 +55,7 @@ var files_settings = {
 		files_elements.files_pdf.prop('checked', (result.files_pdf === '1'));
 		files_elements.files_image.prop('checked', (result.files_image === '1'));
 		files_elements.files_audio.prop('checked', (result.files_audio === '1'));
+    	files_elements.files_open_result_directly.prop('checked', (result.files_open_result_directly === '1'));
 
 		fts_admin_settings.tagSettingsAsSaved(files_elements.files_div);
 	},
@@ -71,7 +72,8 @@ var files_settings = {
 			files_office: (files_elements.files_office.is(':checked')) ? 1 : 0,
 			files_pdf: (files_elements.files_pdf.is(':checked')) ? 1 : 0,
 			files_image: (files_elements.files_image.is(':checked')) ? 1 : 0,
-			files_audio: (files_elements.files_audio.is(':checked')) ? 1 : 0
+			files_audio: (files_elements.files_audio.is(':checked')) ? 1 : 0,
+			files_open_result_directly: (files_elements.files_open_result_directly.is(':checked')) ? 1 : 0
 		};
 		$.ajax({
 			method: 'POST',

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -40,6 +40,9 @@ OC.L10N.register(
     "Extract PDF" : "PDF indizieren",
     "Index the content of PDF files." : "Den Inhalt von PDF-Dateien indizieren.",
     "Extract Office" : "Office-Dateien indizieren",
-    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren."
+    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren.",
+    "Results": "Ergebnisse",
+    "Open Files": "Dateien öffnen",
+    "Directly from search results.": "Direkt aus den Suchergebnissen."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -38,6 +38,9 @@
     "Extract PDF" : "PDF indizieren",
     "Index the content of PDF files." : "Den Inhalt von PDF-Dateien indizieren.",
     "Extract Office" : "Office-Dateien indizieren",
-    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren."
+    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren.",
+    "Results": "Ergebnisse",
+    "Open Files": "Dateien öffnen",
+    "Directly from search results.": "Direkt aus den Suchergebnissen."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -40,6 +40,9 @@ OC.L10N.register(
     "Extract PDF" : "PDF extrahieren",
     "Index the content of PDF files." : "Den Inhalt von PDF-Dateien indizieren.",
     "Extract Office" : "Office-Dateien extrahieren",
-    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren."
+    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren.",
+    "Results": "Ergebnisse",
+    "Open Files": "Dateien öffnen",
+    "Directly from search results.": "Direkt aus den Suchergebnissen."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -38,6 +38,9 @@
     "Extract PDF" : "PDF extrahieren",
     "Index the content of PDF files." : "Den Inhalt von PDF-Dateien indizieren.",
     "Extract Office" : "Office-Dateien extrahieren",
-    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren."
+    "Index the content of office files." : "Den Inhalt von Office-Dateien indizieren.",
+    "Results": "Ergebnisse",
+    "Open Files": "Dateien öffnen",
+    "Directly from search results.": "Direkt aus den Suchergebnissen."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -56,6 +56,7 @@ class ConfigService {
 	public const FILES_IMAGE = 'files_image';
 	public const FILES_AUDIO = 'files_audio';
 	public const FILES_CHUNK_SIZE = 'files_chunk_size';
+	public const FILES_OPEN_RESULT_DIRECTLY = 'files_open_result_directly';
 
 	public $defaults = [
 		self::FILES_LOCAL => '1',
@@ -68,7 +69,8 @@ class ConfigService {
 		self::FILES_OFFICE => '1',
 		self::FILES_IMAGE => '0',
 		self::FILES_AUDIO => '0',
-		self::FILES_CHUNK_SIZE => FilesService::CHUNK_TREE_SIZE
+		self::FILES_CHUNK_SIZE => FilesService::CHUNK_TREE_SIZE,
+		self::FILES_OPEN_RESULT_DIRECTLY => '0'
 	];
 
 

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -345,7 +345,7 @@ class SearchService {
 		if ($this->configService->getAppValue(ConfigService::FILES_OPEN_RESULT_DIRECTLY) !== '1') {
 			$link = $this->urlGenerator->linkToRoute('files.view.index', ['dir' => $dir, 'scrollto' => $filename]);
 		} else {
-			$link = $this->urlGenerator->linkToRoute('files.view.index', ['dir' => $this->withoutEndSlash($dir), 'openfile' => $document->getId(), 'scrollto' => $filename]);
+			$link = $this->urlGenerator->linkToRoute('files.View.showFile', ['fileid' => $document->getId()]);
 		}
 		
 		$document->setLink($link);

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -341,9 +341,14 @@ class SearchService {
 			return;
 		}
 
-		$document->setLink(
-			$this->urlGenerator->linkToRoute('files.view.index', ['dir' => $dir, 'scrollto' => $filename])
-		);
+		
+		if ($this->configService->getAppValue(ConfigService::FILES_OPEN_RESULT_DIRECTLY) !== '1') {
+			$link = $this->urlGenerator->linkToRoute('files.view.index', ['dir' => $dir, 'scrollto' => $filename]);
+		} else {
+			$link = $this->urlGenerator->linkToRoute('files.view.index', ['dir' => $this->withoutEndSlash($dir), 'openfile' => $document->getId(), 'scrollto' => $filename]);
+		}
+		
+		$document->setLink($link);
 	}
 
 

--- a/templates/settings.admin.php
+++ b/templates/settings.admin.php
@@ -152,6 +152,20 @@ Util::addScript(Application::APP_ID, 'admin');
 	-->
 
 		</div>
-	</div>
 
+		<h3 class="hsub"><?php p($l->t('Results')); ?></h3>
+		<div class="div-table">
+			<div class="div-table-row">
+				<div class="div-table-col div-table-col-left">
+					<span class="leftcol"><?php p($l->t('Open Files')); ?>:</span>
+					<br/>
+					<em><?php p($l->t('Directly from search results.')); ?></em>
+				</div>
+				<div class="div-table-col">
+					<input type="checkbox" id="files_open_result_directly" value="1"/>
+				</div>
+			</div>
+		</div>
+
+	</div>
 </div>


### PR DESCRIPTION
The ability to open a file directly from search results, as requested in [Issue #249](https://github.com/nextcloud/files_fulltextsearch/issues/249), is a very useful feature. This idea was initially proposed by [ostasevych](https://github.com/ostasevych) in [Pull Request #250](https://github.com/nextcloud/files_fulltextsearch/pull/250).

I've implemented this feature and added an option to the plugin settings. By default, the current behavior remains unchanged. However, users now have the choice to enable direct opening of files from search results. This enhancement aims to improve user experience by providing a more efficient way to access files through search.

Please review the changes and consider merging them into the main project. Thank you for your consideration!
