### PR TITLE
fix: ensure folders at all levels are properly indexed in getChunksFr…

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -159,6 +159,7 @@ class FilesService {
 				&& $level < $this->configService->getAppValueInt(ConfigService::FILES_CHUNK_SIZE)) {
 				/** @var $file Folder */
 				$entries = array_merge($entries, $this->getChunksFromDirectory($userId, $file, $level));
+                $entries[] = $this->getPathFromRoot($file->getPath(), $userId, true);
 			} else {
 				$entries[] = $this->getPathFromRoot($file->getPath(), $userId, true);
 			}


### PR DESCRIPTION
Just one line that fixes an issue where folders with level less than the configured FILES_CHUNK_SIZE were being recursed into but not added to the index themselves. It concerns the folder itself, not the files within, which are always properly indexed.

The current implementation only indexes folders beyond the  configured FILES_CHUNK_SIZE level, but misses intermediate level folders. This creates inconsistent indexing behavior where some folders appear in search results and others don't, depending only on their depth in the directory structure.

## How to reproduce
1. Find a folder with the required condition (for default settings, a folder on level 2) ) and get its fileid.
  attention: top level folders are not added to the index even with this fix, this is a different issue
2. Check with `php occ fulltextsearch:document:platform files <fileid>`, you will get an error:
``` 404 Not Found: {"_index":"nextcloud_31","_id":"files:1334","found":false} ```
3. After applying the fix and running `php occ fulltextsearch:index`, the folder will be found.

It is not a big issue, since the files are always indexed, still Folders should be added consistently to the index, independent of their level in the directory structure.
