### PR TITLE
ignores shares rename

### DIFF
--- a/lib/Service/FilesService.php
+++ b/lib/Service/FilesService.php
@@ -643,8 +643,6 @@ class FilesService {
 		$this->localFilesService->updateDocumentAccess($document, $file);
 		$this->externalFilesService->updateDocumentAccess($document, $file);
 		$this->groupFoldersService->updateDocumentAccess($document, $file);
-
-		$this->updateShareNames($document, $file);
 	}
 
 
@@ -707,44 +705,6 @@ class FilesService {
 
 		$document->addPart('comments', implode(" \n ", $part));
 	}
-
-
-	/**
-	 * @param FilesDocument $document
-	 * @param Node $file
-	 *
-	 * @return array
-	 */
-	private function updateShareNames(FilesDocument $document, Node $file): array {
-		$users = [];
-
-		$this->localFilesService->getShareUsersFromFile($file, $users);
-		$this->externalFilesService->getShareUsers($document, $users);
-		$this->groupFoldersService->getShareUsers($document, $users);
-
-		$shareNames = [];
-		foreach ($users as $username) {
-			$username = (string)$username;
-
-			try {
-				$user = $this->userManager->get($username);
-				if ($user === null || $user->getLastLogin() === 0) {
-					continue;
-				}
-
-				$path = $this->getPathFromViewerId($file->getId(), $username);
-				$shareNames[$this->secureUsername($username)]
-					= (!is_string($path)) ? $path = '' : $path;
-			} catch (Throwable $e) {
-				$this->logger->debug('Issue while getting information on documentId:' . $document->getId(), ['exception' => $e]);
-			}
-		}
-
-		$document->setInfoArray('share_names', $shareNames);
-
-		return $shareNames;
-	}
-
 
 	/**
 	 * @param string $mimeType

--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -50,8 +50,8 @@ class SearchService {
 	 * @param ISearchRequest $request
 	 */
 	public function improveSearchRequest(ISearchRequest $request) {
-		$this->searchQueryShareNames($request);
-		$this->searchQueryWithinDir($request);
+        $request->addWildcardField('title');
+
 		$this->searchQueryInOptions($request);
 		$this->searchQueryFiltersExtension($request);
 		$this->searchQueryFiltersSource($request);
@@ -61,39 +61,6 @@ class SearchService {
 		$request->addPart('comments');
 		$this->extensionService->searchRequest($request);
 	}
-
-
-	/**
-	 * @param ISearchRequest $request
-	 */
-	private function searchQueryShareNames(ISearchRequest $request) {
-		$username = $this->filesService->secureUsername($request->getAuthor());
-		$request->addField('share_names.' . $username);
-
-		$request->addWildcardField('title');
-		$request->addWildcardField('share_names.' . $username);
-	}
-
-
-	/**
-	 * @param ISearchRequest $request
-	 */
-	private function searchQueryWithinDir(ISearchRequest $request) {
-		$currentDir = $request->getOption('files_within_dir');
-		if ($currentDir === '') {
-			return;
-		}
-
-		$username = $this->filesService->secureUsername($request->getAuthor());
-		$currentDir = trim(str_replace('//', '/', $currentDir), '/') . '/'; // we want the format 'folder/'
-		$request->addRegexFilters(
-			[
-				['share_names.' . $username => $currentDir . '.*'],
-				['title' => $currentDir . '.*']
-			]
-		);
-	}
-
 
 	/**
 	 * @param ISearchRequest $request
@@ -107,7 +74,6 @@ class SearchService {
 		$username = $this->filesService->secureUsername($request->getAuthor());
 		$request->addRegexFilters(
 			[
-				['share_names.' . $username => '.*\.' . $extension],
 				['title' => '.*\.' . $extension]
 			]
 		);
@@ -140,8 +106,6 @@ class SearchService {
 		$in = $request->getOptionArray('in', []);
 
 		if (in_array('filename', $in)) {
-			$username = $this->filesService->secureUsername($request->getAuthor());
-			$request->addLimitField('share_names.' . $username);
 			$request->addLimitField('title');
 		}
 


### PR DESCRIPTION
This become too heavy since the implementation of lazy root folder.
Also useless since Unified Search as the feature is already managed by the normal files search