### PR TITLE
Fix files admin settings without global jQuery

### DIFF
--- a/js/admin.elements.js
+++ b/js/admin.elements.js
@@ -20,31 +20,30 @@ var files_elements = {
 	files_open_result_directly: null,
 
 	init: function () {
-		files_elements.files_div = $('#files');
-		files_elements.files_local = $('#files_local');
-		files_elements.files_external = $('#files_external');
-		files_elements.files_group_folders = $('#files_group_folders');
-		files_elements.files_size = $('#files_size');
-		files_elements.files_office = $('#files_office');
-		files_elements.files_pdf = $('#files_pdf');
-		files_elements.files_open_result_directly = $('#files_open_result_directly');
+		files_elements.files_div = document.getElementById('files');
+		files_elements.files_local = document.getElementById('files_local');
+		files_elements.files_external = document.getElementById('files_external');
+		files_elements.files_group_folders = document.getElementById('files_group_folders');
+		files_elements.files_size = document.getElementById('files_size');
+		files_elements.files_office = document.getElementById('files_office');
+		files_elements.files_pdf = document.getElementById('files_pdf');
+		files_elements.files_open_result_directly = document.getElementById('files_open_result_directly');
 
-		files_elements.files_local.on('change', files_elements.updateSettings);
-		files_elements.files_external.on('change', files_elements.updateSettings);
-		files_elements.files_group_folders.on('change', files_elements.updateSettings);
-		files_elements.files_size.on('change', files_elements.updateSettings);
-		files_elements.files_office.on('change', files_elements.updateSettings);
-		files_elements.files_pdf.on('change', files_elements.updateSettings);
-		files_elements.files_open_result_directly.on('change', files_elements.updateSettings);
+		files_elements.files_local.addEventListener('change', files_elements.updateSettings);
+		files_elements.files_external.addEventListener('change', files_elements.updateSettings);
+		files_elements.files_group_folders.addEventListener('change', files_elements.updateSettings);
+		files_elements.files_size.addEventListener('change', files_elements.updateSettings);
+		files_elements.files_office.addEventListener('change', files_elements.updateSettings);
+		files_elements.files_pdf.addEventListener('change', files_elements.updateSettings);
+		files_elements.files_open_result_directly.addEventListener('change', files_elements.updateSettings);
 	},
 
 
 	updateSettings: function () {
-		fts_admin_settings.tagSettingsAsNotSaved($(this));
+		fts_admin_settings.tagSettingsAsNotSaved(this);
 		files_settings.saveSettings();
 	}
 
 
 };
-
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,22 +7,31 @@
 /** global: files_elements */
 /** global: files_settings */
 
+function ready(callback) {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', callback);
+	} else {
+		callback();
+	}
+}
 
-$(document).ready(function () {
+
+ready(function () {
 
 
 	/**
 	 * @constructs Fts_Files
 	 */
 	var Fts_Files = function () {
-		$.extend(Fts_Files.prototype, files_elements);
-		$.extend(Fts_Files.prototype, files_settings);
+		Object.assign(Fts_Files.prototype, files_elements, files_settings);
 
 		files_elements.init();
 		files_settings.refreshSettingPage();
 	};
 
-	OCA.FullTextSearchAdmin.files = Fts_Files;
-	OCA.FullTextSearchAdmin.files.settings = new Fts_Files();
+	window.OCA = window.OCA || {};
+	window.OCA.FullTextSearchAdmin = window.OCA.FullTextSearchAdmin || {};
+	window.OCA.FullTextSearchAdmin.files = Fts_Files;
+	window.OCA.FullTextSearchAdmin.files.settings = new Fts_Files();
 
 });

--- a/js/admin.settings.js
+++ b/js/admin.settings.js
@@ -15,23 +15,20 @@ var files_settings = {
 
 	refreshSettingPage: function () {
 
-		$.ajax({
-			method: 'GET',
-			url: OC.generateUrl('/apps/files_fulltextsearch/admin/settings')
-		}).done(function (res) {
+		files_settings.request('GET', '/apps/files_fulltextsearch/admin/settings').then(function (res) {
 			files_settings.updateSettingPage(res);
 		});
 
 	},
 
 	updateSettingPage: function (result) {
-		files_elements.files_local.prop('checked', (result.files_local === true));
-		files_elements.files_external.val(result.files_external);
-		files_elements.files_group_folders.prop('checked', (result.files_group_folders === true));
-		files_elements.files_size.val(result.files_size);
-		files_elements.files_office.prop('checked', (result.files_office === true));
-		files_elements.files_pdf.prop('checked', (result.files_pdf === true));
-    	files_elements.files_open_result_directly.prop('checked', (result.files_open_result_directly === true));
+		files_elements.files_local.checked = (result.files_local === true);
+		files_elements.files_external.value = result.files_external;
+		files_elements.files_group_folders.checked = (result.files_group_folders === true);
+		files_elements.files_size.value = result.files_size;
+		files_elements.files_office.checked = (result.files_office === true);
+		files_elements.files_pdf.checked = (result.files_pdf === true);
+		files_elements.files_open_result_directly.checked = (result.files_open_result_directly === true);
 
 		fts_admin_settings.tagSettingsAsSaved(files_elements.files_div);
 	},
@@ -39,24 +36,53 @@ var files_settings = {
 
 	saveSettings: function () {
 		var data = {
-			files_local: (files_elements.files_local.is(':checked')) ? 1 : 0,
-			files_external: files_elements.files_external.val(),
-			files_group_folders: (files_elements.files_group_folders.is(':checked')) ? 1 : 0,
-			files_size: files_elements.files_size.val(),
-			files_office: (files_elements.files_office.is(':checked')) ? 1 : 0,
-			files_pdf: (files_elements.files_pdf.is(':checked')) ? 1 : 0,
-			files_open_result_directly: (files_elements.files_open_result_directly.is(':checked')) ? 1 : 0
+			files_local: files_elements.files_local.checked ? 1 : 0,
+			files_external: files_elements.files_external.value,
+			files_group_folders: files_elements.files_group_folders.checked ? 1 : 0,
+			files_size: files_elements.files_size.value,
+			files_office: files_elements.files_office.checked ? 1 : 0,
+			files_pdf: files_elements.files_pdf.checked ? 1 : 0,
+			files_open_result_directly: files_elements.files_open_result_directly.checked ? 1 : 0
 		};
-		$.ajax({
-			method: 'POST',
-			url: OC.generateUrl('/apps/files_fulltextsearch/admin/settings'),
-			data: {
-				data: data
-			}
-		}).done(function (res) {
+		files_settings.request('POST', '/apps/files_fulltextsearch/admin/settings', data).then(function (res) {
 			files_settings.updateSettingPage(res);
 		});
 
+	},
+
+
+	request: function (method, route, data) {
+		var options = {
+			method: method,
+			credentials: 'same-origin',
+			headers: {
+				'Accept': 'application/json',
+				'requesttoken': window.OC ? window.OC.requestToken : ''
+			}
+		};
+
+		if (method === 'POST') {
+			options.headers['Content-Type'] = 'application/x-www-form-urlencoded;charset=UTF-8';
+			options.body = files_settings.encodeData(data);
+		}
+
+		return fetch(window.OC.generateUrl(route), options).then(function (response) {
+			if (!response.ok) {
+				throw new Error('Request failed: ' + response.status);
+			}
+
+			return response.json();
+		});
+	},
+
+
+	encodeData: function (data) {
+		var params = new URLSearchParams();
+		Object.keys(data).forEach(function (key) {
+			params.append('data[' + key + ']', data[key]);
+		});
+
+		return params.toString();
 	}
 
 


### PR DESCRIPTION
Replaces the files provider admin settings page's global jQuery dependency with vanilla JavaScript. Files provider options such as local files, external files, group folders, max file size, PDF, Office, and direct-open settings now load and save on Nextcloud 34.

Related PRs: [fulltextsearch](https://github.com/nextcloud/fulltextsearch/pull/952) and [fulltextsearch_elasticsearch](https://github.com/nextcloud/fulltextsearch_elasticsearch/pull/473) admin UI fixes should land together.

### Related Links:
- https://github.com/nextcloud/fulltextsearch/pull/952
- https://github.com/nextcloud/fulltextsearch_elasticsearch/pull/473

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
