### PR TITLE
fix(search): do not regex-escape the UID used for file lookups

### DIFF
--- a/lib/Service/SearchService.php
+++ b/lib/Service/SearchService.php
@@ -52,7 +52,7 @@ class SearchService {
 		$this->searchQueryFiltersExtension($request);
 		$this->searchQueryFiltersSource($request);
 		if ($this->userId === '') {
-			$this->userId = $this->filesService->secureUsername($request->getAuthor());
+			$this->userId = $request->getAuthor();
 		}
 		$request->addPart('comments');
 		$this->extensionService->searchRequest($request);


### PR DESCRIPTION
Fixes #389

SearchService::improveSearchRequest() assigned the output of FilesService::secureUsername() -- a regex-escaping helper -- to $this->userId, which is then used as a real user ID. For any user whose UID contains a dot (michael.klemme@example.org becomes michael\.klemme@example.org), getFileFromId() threw NoUserException and improveSearchResult() silently dropped every file result, so the search returned empty.

This only affected code paths without a user session, i.e. occ fulltextsearch:search. In the web UI $this->userId comes from IUserSession and is unescaped, so the same query worked there.

Neither consumer of the field wants an escaped value: getFileFromId() needs a real UID, and substr($file->getPath(), 7 + strlen($this->userId)) needs the real length -- the escaped name is one character too long per dot, so the computed path would be truncated incorrectly even if the lookup succeeded. improveSearchRequest() is also reached after the constructor has already set the same field from the session as a plain UID, which is the field's contract.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
